### PR TITLE
Removed console info

### DIFF
--- a/lib/enforcements/security.js
+++ b/lib/enforcements/security.js
@@ -26,8 +26,6 @@ function username(options, message) {
         options.expr = new RegExp("^[a-z_][a-z0-9_\\-]{" + (options.length - 1) + ",}$", "i");
     }
 
-    console.info(JSON.stringify({ options: options, message: message }));
-
     return patterns.match(options.expr, message);
 }
 exports.username = username;


### PR DESCRIPTION
Calling console.info may not want to be used in production code.  I thought that this may want to be removed in security.js.